### PR TITLE
Make request provider configurable

### DIFF
--- a/index.js
+++ b/index.js
@@ -141,7 +141,9 @@ function mapDependency(module, options, dep){
                 break;
             case 'dojo/request/default':
                 // use module by has features
-                if(checkHasFeature(options, 'host-browser') || checkHasFeature(options, 'host-webworker')){
+                if(checkHasFeature(options, 'config-requestProvider')){
+                    result_module = checkHasFeature(options, 'config-requestProvider')
+                }else if(checkHasFeature(options, 'host-browser') || checkHasFeature(options, 'host-webworker')){
                     result_module = "dojo/request/xhr";
                 }else if(checkHasFeature(options, 'host-node')) {
                     result_module = "dojo/request/node";


### PR DESCRIPTION
The `dojo/request` plugin is configurable, and `dojo/request/default` checks the `config-requestProvider` for a definition of the default request provider. This aligns the `dojo-webpack-loader` with `dojo/request/default` functionality, which specifically allows for configuring `dojo/request/registry` as the default provider, which is a common configuration (at least we use it).
