### PR TITLE
Put root NLS at the NLS object root

### DIFF
--- a/index.js
+++ b/index.js
@@ -141,7 +141,9 @@ function mapDependency(module, options, dep){
                 break;
             case 'dojo/request/default':
                 // use module by has features
-                if(checkHasFeature(options, 'host-browser') || checkHasFeature(options, 'host-webworker')){
+                if(checkHasFeature(options, 'config-requestProvider')){
+                    result_module = checkHasFeature(options, 'config-requestProvider')
+                }else if(checkHasFeature(options, 'host-browser') || checkHasFeature(options, 'host-webworker')){
                     result_module = "dojo/request/xhr";
                 }else if(checkHasFeature(options, 'host-node')) {
                     result_module = "dojo/request/node";
@@ -178,9 +180,7 @@ function processNlsModule(module, parsed, options){
         var f = new Function("'using strict'; return " + parsed.moduleBody + ";");
         var nls_descr = f();
         if (nls_descr && nls_descr.root){
-            var res_nls = {
-                root: nls_descr.root
-            };
+            var res_nls = nls_descr.root
             if (options.includeLanguages){
                 options.includeLanguages.forEach(function(lang){
                    if (nls_descr[lang]){


### PR DESCRIPTION
This isn't complete, but i18n loaded NLS bundles do not seem to export an object in the same format in a webpack bundle that the i18n plugin returns. The generated module contains the available languages (and root) as properties, but the i18n plugin resolves the appropriate language and returns the appropriate language-flattened object. I am not sure if there is a way for the generated module to call something in dojo/i18n do this flattening based on the current locale.

In our app, we got an error loading dgrid/extensions/Pagination, because instead of a `status` object, there is just an object with a `root` property (that contains an object with a `status`). This PR is just a quick hack to resolve to the `root` value instead, because our app just runs in English/root.
