### PR TITLE
Non dojo loaders are left alone

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# dojo-webpack-loader
+# dojo-loader-for-webpack
 [Webpack](https://webpack.github.io/) loader for [Dojo Toolkit 1.x](https://dojotoolkit.org/) (actually, tested with version 1.10). It adapts dojo modules so they can be bundled by webpack and even used out of Dojo Toolkit ecosystem.
 
 Originally, i have wrote this loader to be able to use remarkable [dgrid](http://dgrid.io/) component in my new project which based on webpack. Later i have added support for `dijit` package, so i hope it is enough  to work with most of dojo projects.  If you have any questions or problems with loader, please feel free to ask.

--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ function loaderLibDependency(module, dep_str){
 // Change content of module on load
 function preprocessModule(module, options, content){
     var register_in_dojo_require = module.isNls && module.normalizedName;
-    
+
     switch (module.normalizedName) {
         // for dojo/has - inject staticHasFeatures
         case 'dojo/has':
@@ -59,6 +59,13 @@ function preprocessModule(module, options, content){
         module.inject.append = "})());";
     }
 
+    //support for dojo/domReady!
+    // "dojo/domReady!",  or  ,'dojo/domReady!'  -  both are included in case more than one module is required that doesn't return a variable
+    var domReadyRegExp = /([\"|\']dojo\/domReady![\'|\"]\,)|(\,\s*[\"|\']dojo\/domReady![\'|\"](?!\,))/;
+    var modifiedContent = content.replace(domReadyRegExp, '/* $& */')
+    var isModified = content.length !== modifiedContent.length;
+    content = isModified ? 'require("domready")(function(){' + modifiedContent + '});' : content;
+    
     return content;
 }
 
@@ -174,7 +181,7 @@ function mapDependency(module, options, dep){
     return (result_loaders.length ? result_loaders.join("!") + "!" : "") + result_module;
 }
 
-// Set map of 
+// Set map of
 function processNlsModule(module, parsed, options){
     try {
         var f = new Function("'using strict'; return " + parsed.moduleBody + ";");

--- a/index.js
+++ b/index.js
@@ -65,7 +65,7 @@ function preprocessModule(module, options, content){
     var modifiedContent = content.replace(domReadyRegExp, '/* $& */')
     var isModified = content.length !== modifiedContent.length;
     content = isModified ? 'require("domready")(function(){' + modifiedContent + '});' : content;
-    
+
     return content;
 }
 
@@ -165,7 +165,7 @@ function mapDependency(module, options, dep){
                 // Will be loaded via DojoWebpackLoader
                 break;
             default:
-                debugger;
+                result_loaders.push(norm_dep.loaders[i]);
                 break;
         }
     }

--- a/package.json
+++ b/package.json
@@ -14,13 +14,15 @@
   ],
   "author": "Nordth",
   "license": "MIT",
-  "repository" :
-  { 
-    "type" : "git", 
+  "repository" :  {
+    "type" : "git",
     "url" : "https://github.com/Nordth/dojo-webpack-loader.git"
   },
   "dependencies": {
     "raw-loader": "^0.5.1"
+  },
+  "peerDependencies": {
+    "domready": "^1.0.8"
   },
   "bugs": {
     "url": "https://github.com/Nordth/dojo-webpack-loader/issues"


### PR DESCRIPTION
This was a simple fix, we just needed to add the loaders back in after parsing them out of the request path