### PR TITLE
Changed "raw" to "raw-loader" in index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -152,7 +152,7 @@ function mapDependency(module, options, dep){
                 break;
             case 'dojo/text':
                 // use webpack raw-loader instead of dojo/text
-                result_loaders.push("raw");
+                result_loaders.push("raw-loader");
                 break;
             case 'dojo/i18n':
                 // Will be loaded via DojoWebpackLoader


### PR DESCRIPTION
This change will make this package compatible with Webpack 2 as they no longer accept the short hand "raw" when parsing imports.

https://webpack.js.org/guides/migrating/#automatic-loader-module-name-extension-removed